### PR TITLE
Add a custom entrypoint and print lmhostid before starting lmgrd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,9 @@ RUN yum update -y && yum install -y \
     wget && \
     yum clean all
 
-RUN echo "Downloading..." && \
-    mkdir -p ${TEMP_PATH} && \
-    cd ${TEMP_PATH} && \
-    wget ${NLM_URL} -q && \
-    tar -zxvf *.tar.gz && \
-    echo "Installing..." && \
-    rpm -vhi *.rpm && \
-    echo "Install complete!" && \
+RUN mkdir -p ${TEMP_PATH} && cd ${TEMP_PATH} && \
+    wget --progress=bar:force ${NLM_URL} && \
+    tar -zxvf *.tar.gz && rpm -vhi *.rpm && \
     rm -rf ${TEMP_PATH}
 
 # lmadmin is required for -2 -p flag support
@@ -45,9 +40,5 @@ USER lmadmin
 # Docker will not start sleeping regardless flags.
 ENTRYPOINT ["lmgrd", "-z"]
 
-# default arguments for 'lmgrd', note '-z' is ALWAYS added
+# append additional aguments to 'lmgrd', unless user overrides
 CMD ["-l", "/var/log/flexlm/lmgrd.log", "-c", "/var/flexlm/mayaserver.lic"]
-
-# if you are unsure if the server is running correctly, you can log
-# into the container with ```docker exec -it CONTAINER_ID /bin/bash```
-# once in bash you can run: ```lmutil lmstat -a -c LICENSE_PATH```

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ ENV PATH="${PATH}:/opt/flexnetserver/"
 # do not use ROOT user
 USER lmadmin
 
-# lmgrd -z flag is required to 'Run in foreground.' so that
-# Docker will not start sleeping regardless flags.
-ENTRYPOINT ["lmgrd", "-z"]
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 # append additional aguments to 'lmgrd', unless user overrides
 CMD ["-l", "/var/log/flexlm/lmgrd.log", "-c", "/var/flexlm/mayaserver.lic"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-Running container
----------------------
+Unofficial Autodesk License Manager FLEXlm® Network Server container.
+=====================================================================
+[![Docker Automated buil](https://img.shields.io/docker/automated/haysclark/adlmflexnetserver.svg?maxAge=2592000)](https://hub.docker.com/r/haysclark/adlmflexnetserver/builds/)
 
-    docker run -d -h [LICENSE_HOSTNAME] --mac-address="[LICENSE_MAC_ADRESS]" \
-    -v [FLEXLM_LICENSE_PATH]:/var/flexlm haysclark/adlmflexnetserver
+A simple Docker container that runs Autodesk License Manager FLEXlm® Network Server.
+
+Usage
+-----
+
+    docker run -d -t --mac-address="[LICENSE_MAC_ADRESS]" \
+    -h [LICENSE_HOSTNAME] \
+    -v [FLEXLM_LICENSE_PATH]:/var/flexlm \
+    -p 2080:2080 -p 27000-27009:27000-27009 \
+    haysclark/adlmflexnetserver
 
 All arguments passed to the container are forwarded to 'lmgrd', thus you can provide your own license path or logging path by using the standard arguments.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+lmutil lmhostid
+
+# lmgrd -z flag is required to 'Run in foreground.' so that
+# Docker will not start sleeping regardless flags.
+lmgrd -z $@


### PR DESCRIPTION
Thanks for creating this image! This prints the lmhostid before starting the lmgrd. If the service fails because the license is not valid (or yet to be generated) and the container stops because the service exits, you still are able to get the host id from the container.